### PR TITLE
Fixing and incorrect deletion of a node in sed-tree-del mutator.

### DIFF
--- a/rad/mutations.scm
+++ b/rad/mutations.scm
@@ -641,7 +641,7 @@
                      (inc meta 'tree-swap-two)
                      +1)))))
 
-      (define sed-tree-del (sed-tree-op (λ (node) null) 'tree-del))
+      (define sed-tree-del (sed-tree-op (λ (node) (cdr node)) 'tree-del))
 
       (define sed-tree-dup (sed-tree-op (λ (node) (cons (car node) node)) 'tree-dup))
 


### PR DESCRIPTION
In case of nested tree structures, radamsa sed-tree-del mutator incorrectly deletes a node, breaking a tree structure. E.g. in case of input:
'123' {456} [123, (123) ] radamsa may return '123' {456} [123, . This is because sed-tree-op lambda return null instead of node tail.
