### PR TITLE
make: correct rules for $(OWL).c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ radamsa.fasl: rad/*.scm bin/ol
 
 $(OWL).c:
 	test -f $(OWL).c.gz || wget $(OWLURL)/$(OWL).c.gz
+	gzip -d < $(OWL).c.gz > $(OWL).c
 
 bin/ol: $(OWL).c
-	gzip -d < $(OWL).c.gz > $(OWL).c
 	mkdir -p bin
 	cc -O2 -o bin/ol $(OWL).c
 


### PR DESCRIPTION
`$(OWL).c` rule should end up creating `$(OWL).c` else be declared as `PHONY`.  `bin/ol` depends on `$(OWL).c` but no rule ended up creating one.

Another approach would be to decompose `$(OWL).c` into two targets: `$(OWL).c.gz` and `$(OWL).c`.