### PR TITLE
Add wget to nutshell example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Radamsa is a test case generator for robustness testing, a.k.a. a fuzzer. It is 
 
 ```
  $ # please please please fuzz your programs. here is one way to get data for it:
- $ sudo apt-get install gcc make git
+ $ sudo apt-get install gcc make git wget
  $ git clone https://github.com/aoh/radamsa.git && cd radamsa && make && sudo make install
  $ echo "HAL 9000" | radamsa
 ```


### PR DESCRIPTION
Add wget package to nutshell example in README.md as it might not be installed by default (e.g. in official Ubuntu Docker images).